### PR TITLE
Make instance list fill until scrollbars

### DIFF
--- a/src/components/elements/lists/AutoLoadObjectList.js
+++ b/src/components/elements/lists/AutoLoadObjectList.js
@@ -1,7 +1,6 @@
 import ObjectRow from "./rows/ObjectRow";
 import ErrorsBox from "../../errors/ErrorsBox";
 import CenteredCircularProgress from "../progress/CenteredCircularProgress";
-import { useState } from "react";
 
 const AutoLoadObjectList = ({
   data,
@@ -15,18 +14,13 @@ const AutoLoadObjectList = ({
   filterFields,
   onLoadDetails,
   onDetails,
-  setPage,
+  setParentPageState,
+  parentPageState,
 }) => {
-  const [totalPages, setTotalPages] = useState(0);
-
   const handleScroll = ({ target }) => {
-    const offset = window.innerHeight / 2;
-
-    const page = Math.round(target.scrollTop / offset) + 1;
-
-    if (page > totalPages) {
-      setTotalPages(page);
-      setPage(totalPages);
+    const bottom = target.scrollHeight - target.scrollTop === target.clientHeight;
+    if (bottom) {
+      setParentPageState(parentPageState + 1);
     }
   };
 

--- a/src/components/elements/lists/AutoLoadObjectList.js
+++ b/src/components/elements/lists/AutoLoadObjectList.js
@@ -1,6 +1,7 @@
 import ObjectRow from "./rows/ObjectRow";
 import ErrorsBox from "../../errors/ErrorsBox";
 import CenteredCircularProgress from "../progress/CenteredCircularProgress";
+import { useEffect, useRef, useState } from "react";
 
 const AutoLoadObjectList = ({
   data,
@@ -16,10 +17,34 @@ const AutoLoadObjectList = ({
   onDetails,
   setParentPageState,
   parentPageState,
+  endOfData,
 }) => {
+  const objectListRef = useRef(null);
+
+  const pageFilled = (rows) => {
+    let totalHeight = 0;
+    Array.from(rows).forEach((row) => {
+      totalHeight += row.clientHeight;
+    });
+
+    const parentHeight = objectListRef.current.clientHeight;
+
+    return totalHeight > parentHeight;
+  };
+
+  const [pageIsFilled, setPageIsFilled] = useState(false);
+
+  useEffect(() => {
+    setPageIsFilled(pageFilled(objectListRef.current.children));
+    if (!pageIsFilled && !endOfData) {
+      setParentPageState(parentPageState + 1);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [endOfData, pageIsFilled]);
+
   const handleScroll = ({ target }) => {
     const bottom = target.scrollHeight - target.scrollTop === target.clientHeight;
-    if (bottom) {
+    if (bottom && !endOfData) {
       setParentPageState(parentPageState + 1);
     }
   };
@@ -72,7 +97,7 @@ const AutoLoadObjectList = ({
     } else {
       if (data) {
         return (
-          <div className="ObjectList" style={{ overflow: "scroll" }} onScroll={handleScroll}>
+          <div className="ObjectList" style={{ overflow: "scroll" }} onScroll={handleScroll} ref={objectListRef}>
             {header(timeFieldLabel, data, onDetailsRequest)}
             {rows(timeField, filterFields, allRows, onDetailsRequest, onDetails)}
           </div>

--- a/src/components/pages/Instances.js
+++ b/src/components/pages/Instances.js
@@ -10,24 +10,29 @@ export default function Instances() {
   const [loading, setLoading] = useState(true);
   const [errors, setErrors] = useState(null);
   const [page, setPage] = useState(0);
+  const [endOfData, setEndOfData] = useState(false);
 
   useEffect(() => {
-    request(
-      {
-        url: `/instances/page/${page}`,
-        method: "GET",
-      },
-      setLoading,
-      (e) => {
-        setErrors(e);
-      },
-      (response) => {
-        if (response) {
-          setData(response.data);
-          setRows([...rows, ...response.data.result]);
+    !endOfData &&
+      request(
+        {
+          url: `/instances/page/${page}`,
+          method: "GET",
+        },
+        setLoading,
+        (e) => {
+          setErrors(e);
+        },
+        (response) => {
+          if (response) {
+            if (response.data.result.length === 0) {
+              setEndOfData(true);
+            }
+            setData(response.data);
+            setRows([...rows, ...response.data.result]);
+          }
         }
-      }
-    );
+      );
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [page]);
 
@@ -47,6 +52,7 @@ export default function Instances() {
         timeFieldLabel="Timestamp"
         setParentPageState={setPage}
         parentPageState={page}
+        endOfData={endOfData}
       />
     );
   }

--- a/src/components/pages/Instances.js
+++ b/src/components/pages/Instances.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { request } from "../../remote_api/uql_api_endpoint";
 import ErrorsBox from "../errors/ErrorsBox";
 import AutoLoadObjectList from "../elements/lists/AutoLoadObjectList";
+import CenteredCircularProgress from "../elements/progress/CenteredCircularProgress";
 
 export default function Instances() {
   const [data, setData] = useState(null);
@@ -28,7 +29,11 @@ export default function Instances() {
       }
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [loading, page]);
+  }, [page]);
+
+  if (loading) {
+    return <CenteredCircularProgress />;
+  }
 
   if (data) {
     return (
@@ -40,7 +45,8 @@ export default function Instances() {
         loading={loading}
         timeField={(row) => [row.timestamp]}
         timeFieldLabel="Timestamp"
-        setPage={setPage}
+        setParentPageState={setPage}
+        parentPageState={page}
       />
     );
   }


### PR DESCRIPTION
Hi Risto,

I think this might solve what we were discussing previously. The AutoLoadObject list now uses useRef to determine if the ObjectList is larger than the clientHeight of the parent, and increments the page counter until it reaches that condition or detects an empty array has been returned. After that, the endOfData boolean keeps the api from being called again at the page level, so the only subsequent calls should be if the bottom of the scroll is reached and there has not been an empty array returned. 

I'm hoping this allows you to not worry about chunk size on the backend. I haven't been able to fully test these changes but all the logs and network calls suggest it is working as intended. Please let me know if there are any issues, thanks!

Best,
Daniel